### PR TITLE
Allow installing on external storage (SD card)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.jfedor.frozenbubble"
+  android:installLocation="auto"
   android:versionCode="54"
   android:versionName="4.4">
 


### PR DESCRIPTION
We have to declare that the app may be moved to the SD card to save space on the internal storage.

See
- https://developer.android.com/guide/topics/data/install-location
- https://developer.android.com/guide/topics/manifest/manifest-element#install